### PR TITLE
bump compat of Setfield to v1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Setfield = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8"
+Setfield = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1.0"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
I don't know why CompatHelper did not run for this change. The last CompatHelper PR seems to be https://github.com/JuliaFolds/SplittablesBase.jl/pull/66...